### PR TITLE
Add Docker support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,14 @@ In order to build the documentation site, you will need:
 * Python 2 - the [Pygments](https://github.com/tmm1/pygments.rb) gem uses Python for syntax highlighting.
 * `gem install bundler` - the site uses [Bundler](http://bundler.io) to manage gem dependencies within the repo, rather than globally installing to the local operating system.
 
+**Docker**
+
+To install this site on Docker, simply execute the following commands.
+
+* `cd docker`
+* `docker build -t intellij-sdk-docs .`
+* `docker run -it -p 4000:4000 intellij-sdk-docs /bin/bash -c 'cd intellij-sdk-docs && rake preview'`
+
 **OS X**
 
 OS X comes with Ruby and Python already installed. The only steps required are:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:14.04
+
+RUN \
+  apt-get install --yes software-properties-common && \
+  apt-get install --yes python && \
+  add-apt-repository --yes ppa:brightbox/ruby-ng && \
+  add-apt-repository --yes ppa:chris-lea/node.js && \
+  apt-get update && \
+  apt-get install --yes vim curl git
+
+RUN \
+  apt-get install --yes ruby2.1 ruby2.1-dev bundler && \
+  apt-get install --yes libghc-zlib-dev && \
+  apt-get install --yes nodejs
+
+RUN \
+  gem install bundler && \
+# git clone --depth 1 http://github.com/jetbrains/intellij-sdk-docs && \
+  git clone --depth 1 http://github.com/breandan/intellij-sdk-docs && \
+  cd intellij-sdk-docs && \
+  git submodule init && \
+  git submodule update
+
+RUN \
+  cd intellij-sdk-docs && \
+  rake bootstrap
+
+EXPOSE 4000


### PR DESCRIPTION
Add support for installing intellij-sdk-docs on a Docker host.

When [Migrate to sdkdocs_template](https://github.com/JetBrains/intellij-sdk-docs/pull/6) is merged, [line 18](https://github.com/citizenmatt/intellij-sdk-docs/compare/sdkdocs-template...breandan:master#diff-ebacf6f6ae4ee68078bb16454b23247dR18) needs to be uncommented and [line 19](https://github.com/citizenmatt/intellij-sdk-docs/compare/sdkdocs-template...breandan:master#diff-ebacf6f6ae4ee68078bb16454b23247dR19) must be removed.